### PR TITLE
Fix livekit bidirectional ai connection

### DIFF
--- a/frontend/flutter_app/lib/core/config/app_config.dart
+++ b/frontend/flutter_app/lib/core/config/app_config.dart
@@ -7,20 +7,15 @@ class AppConfig {
 
   // Fonction utilitaire pour substituer localhost avec l'IP correcte en mode debug
   static String _replaceLocalhostWithDevIp(String url) {
-    if (kDebugMode && url.contains('localhost')) {
-      // FIX: Utiliser l'IP machine hôte pour tous les cas car Docker expose sur 0.0.0.0
-      const devIp = '192.168.1.44';
-      final newUrl = url.replaceFirst('localhost', devIp);
-      debugPrint('🌐 URL remplacée: $url → $newUrl');
-      return newUrl;
-    }
+    // Ne force plus une IP fixe; laisse l'environnement contrôler.
+    // Si nécessaire, l'app peut fournir une URL déjà correcte via .env
     return url;
   }
 
   // URLs des services
   static String get livekitUrl {
     final url = dotenv.env['LIVEKIT_URL'] ?? 'ws://localhost:7880';
-    return isProduction ? "wss://your-prod-server.com" : _replaceLocalhostWithDevIp(url);
+    return isProduction ? url : _replaceLocalhostWithDevIp(url);
   }
 
   // Clés API LiveKit

--- a/frontend/flutter_app/lib/data/models/session_model.dart
+++ b/frontend/flutter_app/lib/data/models/session_model.dart
@@ -36,7 +36,7 @@ class SessionModel {
       
       final sessionId = json['session_id'] ?? '';
       final roomName = json['room_name'] ?? (json['session_id'] != null ? 'eloquence-${json['session_id']}' : ''); // Fallback pour room_name si non présent avec les clés livekit
-      final token = json['livekit_token'] ?? '';
+      final token = (json['livekit_token'] ?? json['token'] ?? '') as String; // Supporte aussi 'token'
       final livekitUrl = json['livekit_url'] ?? '';
       final initialMessageData = json['initial_message'];
 

--- a/frontend/flutter_app/lib/features/confidence_boost/data/services/confidence_livekit_service.dart
+++ b/frontend/flutter_app/lib/features/confidence_boost/data/services/confidence_livekit_service.dart
@@ -192,7 +192,7 @@ class ConfidenceLiveKitService {
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final livekitUrl = AppConfig.livekitUrl.replaceAll('localhost', '192.168.1.44');
+        final livekitUrl = AppConfig.livekitUrl;
         
         return {
           'token': data['token'],
@@ -745,7 +745,7 @@ class ConfidenceLiveKitService {
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        final livekitUrl = AppConfig.livekitUrl.replaceAll('localhost', '192.168.1.44');
+        final livekitUrl = AppConfig.livekitUrl;
         
         return {
           'token': data['token'],

--- a/frontend/flutter_app/lib/src/services/clean_livekit_service.dart
+++ b/frontend/flutter_app/lib/src/services/clean_livekit_service.dart
@@ -107,7 +107,7 @@ class CleanLiveKitService extends ChangeNotifier {
         _logger.i('[DIAGNOSTIC] Starting connection attempt...');
         
         await _room!.connect(
-          AppConfig.livekitUrl, // Utilisation de AppConfig.livekitUrl
+          url,
           token,
           connectOptions: connectOptions,
         );

--- a/services/livekit-server/main.py
+++ b/services/livekit-server/main.py
@@ -30,7 +30,7 @@ app.add_middleware(
 
 # Configuration LiveKit depuis les variables d'environnement
 LIVEKIT_API_KEY = os.getenv("LIVEKIT_API_KEY", "devkey")
-LIVEKIT_API_SECRET = os.getenv("LIVEKIT_API_SECRET", "secret")
+LIVEKIT_API_SECRET = os.getenv("LIVEKIT_API_SECRET", "devsecret123456789abcdef0123456789abcdef")
 LIVEKIT_URL = os.getenv("LIVEKIT_URL", "ws://localhost:7880")
 
 # Cache de tokens actifs (en production, utiliser Redis)


### PR DESCRIPTION
Fix LiveKit connection by ensuring the Flutter app uses dynamic session URLs and valid tokens, and removing environment-specific IP overrides.

The LiveKit connection was failing because the Flutter app was incorrectly using a static LiveKit URL instead of the session-specific one provided by the API, leading to problems with internal Docker hostnames. Additionally, hardcoded `localhost` to `192.168.1.44` IP replacements caused connection failures in non-matching environments. Finally, the LiveKit token service was generating invalid tokens because its default secret did not match the LiveKit server's expected secret. This PR addresses these three root causes.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbfedffb-42c4-4842-8089-4686d0da570c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbfedffb-42c4-4842-8089-4686d0da570c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

